### PR TITLE
feat: Add 500 error test case

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -1,6 +1,6 @@
 # Importing flask module in the project is mandatory
 # An object of Flask class is our WSGI application.
-from flask import Flask, jsonify
+from flask import Flask, jsonify, abort
 from utils.berry_stats import BerryStats
 import os
 from app.main import bp
@@ -15,10 +15,13 @@ def hello_world():
 
 @bp.route('/allBerryStats')
 def all_berry_stats():
-    url = os.getenv('POKEAPI_BERRY_BASE_URL')
-    print(url)
-    allBerryStats = BerryStats(url)
-    allBerryStats.fetch_stats()
-    stats_dict = allBerryStats.calculate_stats()
-    print(stats_dict)
+    try:
+        url = os.getenv('POKEAPI_BERRY_BASE_URL')
+        print(url)
+        allBerryStats = BerryStats(url)
+        allBerryStats.fetch_stats()
+        stats_dict = allBerryStats.calculate_stats()
+        print(stats_dict)
+    except:
+        abort(500)
     return jsonify(stats_dict)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import os
 import pytest
 from app import create_app
 from config import Config
+from pytest import MonkeyPatch
 
 # --------
 # Config
@@ -24,3 +25,11 @@ def test_client():
         # Establish an application context
         with flask_app.app_context():
             yield testing_client
+
+@pytest.fixture(scope='module')
+def patched_test_client(test_client):
+    with MonkeyPatch.context() as mp:
+        def mock_return(self):
+            raise Exception("Mock request failed")
+        mp.setattr("app.main.routes.BerryStats.fetch_stats", mock_return)
+        yield test_client

--- a/tests/functional/test_allberrystats.py
+++ b/tests/functional/test_allberrystats.py
@@ -52,3 +52,12 @@ def test_allberrystats_page_with_fixture(test_client):
     assert 'variance_growth_time' in data
     assert 'mean_growth_time' in data
     assert 'frequency_growth_time' in data
+
+def test_allberrystats_page_with_monkeypatch_error_fixture(patched_test_client):
+    """
+    GIVEN a Flask application configured for testing
+    WHEN the '/allBerryStats' page is posted to (GET) but the ARG_POKEAPI_BERRY_BASE_URL is set to a wrong value
+    THEN check that the response is invalid (500)
+    """
+    response = patched_test_client.get('/allBerryStats')
+    assert response.status_code == 500


### PR DESCRIPTION
500 error case for allberrystats endpoint

Created test with monkeypatch in order to throw exception when calling fetch_stats() method from BerryStats instance

Modified enpoint handler to comply with new test